### PR TITLE
fix navigation bar issues on loading and result page

### DIFF
--- a/Should I Run.xcodeproj/project.pbxproj
+++ b/Should I Run.xcodeproj/project.pbxproj
@@ -54,7 +54,6 @@
 		2508AF741975C10800E48B37 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		252ADD871978357600ED0C3F /* ResultViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultViewController.swift; sourceTree = "<group>"; };
 		252ADD8919784C1800ED0C3F /* LoadingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
-		252ADD8B1978546000ED0C3F /* MyPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = MyPlayground.playground; sourceTree = "<group>"; };
 		2536F76A1976EC6600A2CE2B /* XMLReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLReader.h; sourceTree = "<group>"; };
 		2536F76B1976EC7D00A2CE2B /* Should I Run-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Should I Run-Bridging-Header.h"; sourceTree = "<group>"; };
 		2536F76C1976EC7D00A2CE2B /* XMLReader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMLReader.m; sourceTree = "<group>"; };
@@ -125,7 +124,6 @@
 				2536F76B1976EC7D00A2CE2B /* Should I Run-Bridging-Header.h */,
 				2536F76E197702CA00A2CE2B /* UserLocationManager.swift */,
 				252ADD871978357600ED0C3F /* ResultViewController.swift */,
-				252ADD8B1978546000ED0C3F /* MyPlayground.playground */,
 			);
 			path = "Should I Run";
 			sourceTree = "<group>";

--- a/Should I Run/Base.lproj/Main.storyboard
+++ b/Should I Run/Base.lproj/Main.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6185.7" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="H3J-Mj-aFw">
     <dependencies>
+        <deployment defaultVersion="1808" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6181.2"/>
     </dependencies>
     <scenes>
@@ -61,7 +62,7 @@
                         <viewControllerLayoutGuide type="bottom" id="T9T-o1-wLW"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="wrt-e8-Qnc">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Loading" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X9y-F0-31e">
@@ -73,7 +74,17 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
-                    <navigationItem key="navigationItem" id="Hbw-0V-3hj"/>
+                    <navigationItem key="navigationItem" id="Hbw-0V-3hj">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="8Lp-xV-1HW">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="TJE-Pm-rQE">
+                                <rect key="frame" x="-23" y="-15" width="71" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title=" ">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <segue destination="8qB-Tw-PfR" kind="push" identifier="ResultsSegue" id="PoU-Ol-HGj"/>
                     </connections>
@@ -91,7 +102,7 @@
                         <viewControllerLayoutGuide type="bottom" id="svA-2S-M0p"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Eea-UV-eIr">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KwT-He-R3e">
@@ -211,7 +222,20 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
-                    <navigationItem key="navigationItem" id="280-uE-09o"/>
+                    <navigationItem key="navigationItem" id="280-uE-09o">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="x6r-sV-eQd">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="vXF-xe-DBE">
+                                <rect key="frame" x="-23" y="-15" width="71" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Back">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <segue destination="Erf-vT-Gbs" kind="unwind" unwindAction="unwindToList:" id="Xjm-eg-kjB"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="alarmButton" destination="WKn-3F-unA" id="Dqy-pW-i78"/>
                         <outlet property="destinationLabel" destination="huy-5W-OZJ" id="7TL-Zm-dc8"/>
@@ -227,6 +251,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wny-FK-IBg" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="Erf-vT-Gbs" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="2145" y="220"/>
         </scene>
@@ -239,7 +264,7 @@
                         <viewControllerLayoutGuide type="bottom" id="fSE-mq-6iZ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="zfS-b1-tTb">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Get a reminder in..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oa3-LW-1et">
@@ -258,7 +283,6 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" id="hmx-zy-7aK">
-                        <barButtonItem key="backBarButtonItem" title="Cancel" id="14E-12-rly"/>
                         <barButtonItem key="rightBarButtonItem" title="Save" style="done" id="Bs2-Pa-RyS">
                             <connections>
                                 <segue destination="s5l-Yx-r0J" kind="unwind" unwindAction="unwindToList:" id="TQB-IX-NaG"/>

--- a/Should I Run/LoadingViewController.swift
+++ b/Should I Run/LoadingViewController.swift
@@ -124,9 +124,5 @@ class LoadingViewController: UIViewController, BartApiControllerDelegate, Google
         destinationController.departureStationName = self.departureStationName
         destinationController.departures = self.bartResults!
     }
-
-    
-
-    
     
 }

--- a/Should I Run/ResultViewController.swift
+++ b/Should I Run/ResultViewController.swift
@@ -131,7 +131,7 @@ class ResultViewController: UIViewController {
     
     func unwindToList(segue:UIStoryboardSegue)  {
         //reload the view on unwinding
-        
+        println("unwindToList called in ResultView")
     }
 }
 


### PR DESCRIPTION
Fixes two issues:
1) Removes the back button from the loading page, which was buggy
2) Correctly segues to Main Screen from tapping back in Results, skipping over Loading
